### PR TITLE
fix problem with [] in f-string

### DIFF
--- a/deconverter.py
+++ b/deconverter.py
@@ -85,8 +85,10 @@ def deconvert_strings_in_file(rd_file_p, wr_file_p):
   with open(rd_file_p, "r") as rd_file:
     file_data = rd_file.read()
     with open(wr_file_p, "w") as wr_file:
-      patern1 = re.compile('[f]{1,1}["]{1,1}[\s\S]*?[!\\]+["]{1,1}')
-      patern2 = re.compile('[f]{1,1}[\']{1,1}[\s\S]*?[!\\]+[\']{1,1}')
+      #patern1 = re.compile('[f]{1,1}["]{1,1}[\s\S]*?[!\\]+["]{1,1}')
+      #patern2 = re.compile('[f]{1,1}[\']{1,1}[\s\S]*?[!\\]+[\']{1,1}')
+      patern1 = re.compile('[f]{1,1}["]{1,1}.+["]{1,1}')
+      patern2 = re.compile('[f]{1,1}[\']{1,1}.+[\']{1,1}')
       f_strings = chain(re.finditer(patern1, file_data), 
                         re.finditer(patern2, file_data))
       total_f_strings = [(s.start(), s.end()) for s in f_strings]


### PR DESCRIPTION
I found that `print(f"hello, {name[0]}")` came out with `print("hello, {.format(nam)0]}")` in `deconvert_strings_in_file()`, so I fix the regular expression of matching patterns in file, and it also works with pattern like `print(f"hello, \"{name[0]}\"")`